### PR TITLE
Backward compatibility on Php Syntax

### DIFF
--- a/Model/EmailProviderResult.php
+++ b/Model/EmailProviderResult.php
@@ -39,7 +39,7 @@ class EmailProviderResult implements JsonSerializable
     /**
      * @return string
      */
-    public function getStatus(): string
+    public function getStatus()
     {
         return $this->status;
     }
@@ -47,7 +47,7 @@ class EmailProviderResult implements JsonSerializable
     /**
      * @return array
      */
-    public function getRawResults(): array
+    public function getRawResults()
     {
         return $this->rawResults;
     }

--- a/Model/HContent.php
+++ b/Model/HContent.php
@@ -31,7 +31,7 @@ class HContent implements JsonSerializable
     /**
      * @return string
      */
-    public function getType(): string
+    public function getType()
     {
         return $this->type;
     }
@@ -39,7 +39,7 @@ class HContent implements JsonSerializable
     /**
      * @return string
      */
-    public function getText(): string
+    public function getText()
     {
         return $this->text;
     }

--- a/Model/HEmail.php
+++ b/Model/HEmail.php
@@ -35,7 +35,7 @@ class HEmail implements JsonSerializable
     /**
      * @return string
      */
-    public function getAddress(): string
+    public function getAddress()
     {
         return $this->address;
     }

--- a/Model/HMail.php
+++ b/Model/HMail.php
@@ -90,7 +90,7 @@ class HMail implements JsonSerializable
     /**
      * @param string $subject
      */
-    public function setSubject(string $subject)
+    public function setSubject($subject)
     {
         $this->subject = $subject;
     }

--- a/Model/HMail.php
+++ b/Model/HMail.php
@@ -75,14 +75,14 @@ class HMail implements JsonSerializable
         $this->attachments[] = $a;
     }
 
-    public function getAttachments(): array {
+    public function getAttachments() {
         return $this->attachments;
     }
 
     /**
      * @return string
      */
-    public function getSubject(): string
+    public function getSubject()
     {
         return $this->subject;
     }
@@ -99,7 +99,7 @@ class HMail implements JsonSerializable
     /**
      * @return HEmail
      */
-    public function getFrom(): HEmail
+    public function getFrom()
     {
         return $this->from;
     }
@@ -115,7 +115,7 @@ class HMail implements JsonSerializable
     /**
      * @return HContent
      */
-    public function getContent(): HContent
+    public function getContent()
     {
         return $this->content;
     }
@@ -148,7 +148,7 @@ class HMail implements JsonSerializable
         /**
          * @return HEmail[]
          */
-        public function getTo(): array
+        public function getTo()
         {
             return $this->to;
         }
@@ -181,7 +181,7 @@ class HMail implements JsonSerializable
         /**
          * @return HEmail[]
          */
-        public function getCC(): array
+        public function getCC()
         {
             return $this->cc;
         }
@@ -214,7 +214,7 @@ class HMail implements JsonSerializable
         /**
          * @return HEmail[]
          */
-        public function getBCC(): array
+        public function getBCC()
         {
             return $this->bcc;
         }

--- a/Model/HMailSendAttempt.php
+++ b/Model/HMailSendAttempt.php
@@ -103,7 +103,7 @@ class HMailSendAttempt implements JsonSerializable
     /**
      * @return string
      */
-    public function getProviderName(): string
+    public function getProviderName()
     {
         return $this->providerName;
     }
@@ -119,7 +119,7 @@ class HMailSendAttempt implements JsonSerializable
     /**
      * @return string
      */
-    public function getAttemptStatus(): string
+    public function getAttemptStatus()
     {
         return $this->attemptStatus;
     }
@@ -135,7 +135,7 @@ class HMailSendAttempt implements JsonSerializable
     /**
      * @return HMail
      */
-    public function getMessage(): HMail
+    public function getMessage()
     {
         return $this->message;
     }

--- a/Model/HMailSendAttempt.php
+++ b/Model/HMailSendAttempt.php
@@ -111,7 +111,7 @@ class HMailSendAttempt implements JsonSerializable
     /**
      * @param string $providerName
      */
-    public function setProviderName(string $providerName)
+    public function setProviderName($providerName)
     {
         $this->providerName = $providerName;
     }
@@ -127,7 +127,7 @@ class HMailSendAttempt implements JsonSerializable
     /**
      * @param string $attemptStatus
      */
-    public function setAttemptStatus(string $attemptStatus)
+    public function setAttemptStatus($attemptStatus)
     {
         $this->attemptStatus = $attemptStatus;
     }


### PR DESCRIPTION
7.x > 5.x

@oxnel88 I made a changes to remove Return type for backward compatibility. Can you pls review and apply merge if its ok.

Thanks